### PR TITLE
os_specific: zephyr: update AcpiOsGetTimer with arch or platform specific implementation

### DIFF
--- a/source/os_specific/service_layers/oszephyr.c
+++ b/source/os_specific/service_layers/oszephyr.c
@@ -967,7 +967,7 @@ UINT64
 AcpiOsGetTimer (
     void)
 {
-    return (k_cycle_get_64 ());
+    return acpi_timer_get();
 }
 
 


### PR DESCRIPTION
update AcpiOsGetTimer implementation with arch/platform specific implementation (acpi_timer_get) instead of using sys_clock_cycle_get_64 which might internally use hpet timer etc. if it enabled as system timer and can cause raise condition if AcpiOsGetTimer invoked before those timer driver instantiate.