### PR TITLE
os_specific: zephyr: update AcpiOsGetTimer with arch specific timer 

### DIFF
--- a/source/os_specific/service_layers/oszephyr.c
+++ b/source/os_specific/service_layers/oszephyr.c
@@ -967,7 +967,7 @@ UINT64
 AcpiOsGetTimer (
     void)
 {
-    return (k_cycle_get_64 ());
+    return acpi_timer_get();
 }
 
 


### PR DESCRIPTION
update AcpiOsGetTimer implementation with arch specific timer implementation instead of using system timer which might use driver interface such as HPET and this might cause init priority issue if a driver which need to init before system timer driver instantiate.