### PR TITLE
zephyr: rename of z_phys_un/map to mm_memmap_phys_bare_*

### DIFF
--- a/source/os_specific/service_layers/oszephyr.c
+++ b/source/os_specific/service_layers/oszephyr.c
@@ -805,7 +805,7 @@ AcpiOsMapMemory (
     uint8_t                 *VirtlAdd;
 
     LOG_DBG ("");
-    z_phys_map (&VirtlAdd, Where, Length, K_MEM_PERM_RW);
+    mm_memmap_phys_bare_map (&VirtlAdd, Where, Length, K_MEM_PERM_RW);
     return ((void *) VirtlAdd);
 }
 #endif
@@ -831,7 +831,7 @@ AcpiOsUnmapMemory (
     ACPI_SIZE               Length)
 {
     LOG_DBG ("");
-    z_phys_unmap (Where, Length);
+    mm_memmap_phys_bare_unmap (Where, Length);
 }
 
 


### PR DESCRIPTION
The Zephyr kernel has renamed z_phys_map() and z_phys_unmap() to mm_memmap_phys_bare_map() and mm_mem_phys_bare_unmap() repsectively. So update the function calls.