### PR TITLE
zephyr: rename mm_memmap_phys_bare_* to k_mem_phys_bare_*

### DIFF
--- a/source/os_specific/service_layers/oszephyr.c
+++ b/source/os_specific/service_layers/oszephyr.c
@@ -805,7 +805,7 @@ AcpiOsMapMemory (
     uint8_t                 *VirtlAdd;
 
     LOG_DBG ("");
-    mm_memmap_phys_bare_map (&VirtlAdd, Where, Length, K_MEM_PERM_RW);
+    k_mem_map_phys_bare (&VirtlAdd, Where, Length, K_MEM_PERM_RW);
     return ((void *) VirtlAdd);
 }
 #endif
@@ -831,7 +831,7 @@ AcpiOsUnmapMemory (
     ACPI_SIZE               Length)
 {
     LOG_DBG ("");
-    mm_memmap_phys_bare_unmap (Where, Length);
+    k_mem_unmap_phys_bare (Where, Length);
 }
 
 


### PR DESCRIPTION
The Zephyr kernel has renamed z_phys_map() and z_phys_unmap() to k_mem_phys_bare_map() and k_mem_phys_bare_unmap() repsectively. So update the function calls. The mm_memmap_* was an intermediate step, and hence we are renamed from that.